### PR TITLE
Fix help text for deps command

### DIFF
--- a/run
+++ b/run
@@ -18,7 +18,7 @@ show_help() {
   echo "  db:reset    - Reset the database (drop, create, migrate, seed)"
   echo "  db:migrate  - Run database migrations"
   echo "  db:seed     - Seed the database"
-  echo "  deps        - Install all dependencies (bundle, yarn)"
+  echo "  deps        - Install all dependencies (bundle, npm)"
   echo "  routes      - List all routes"
   echo "  help        - Show this help message"
   echo ""


### PR DESCRIPTION
## Summary
- update `run` help description for the `deps` command to mention npm

## Testing
- `bundle exec rspec` *(fails: ruby 3.3.6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863028e8930833094492144d7cd7db1