### PR TITLE
Add rails_helper setup and user email spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'is invalid without an email' do
+    user = User.new(password: 'password123', password_confirmation: 'password123')
+    expect(user).not_to be_valid
+    expect(user.errors[:email]).to be_present
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,18 @@
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../config/environment', __dir__)
+abort('The Rails environment is running in production mode!') if Rails.env.production?
+require 'rspec/rails'
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+
+  # You can uncomment this line to turn off ActiveRecord support entirely.
+  # config.use_active_record = false
+
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+end


### PR DESCRIPTION
## Summary
- load Rails env in `spec/rails_helper.rb`
- validate presence of email in User model spec

## Testing
- `bundle exec rspec --format doc --out /tmp/rspec.txt` *(fails: ruby-3.3.6 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686302966ba88330adb0c4d75ea81608